### PR TITLE
rework raspberry pico examples

### DIFF
--- a/examples/raspberrypi-rp2040/build.zig
+++ b/examples/raspberrypi-rp2040/build.zig
@@ -1,34 +1,34 @@
 const std = @import("std");
-const rp2040 = @import("rp2040");
+const rp2040 = @import("microzig-bsp-rp2040");
+const MicroZig = @import("microzig");
 
 const available_examples = [_]Example{
-    .{ .name = "pico_adc", .target = rp2040.boards.raspberry_pi.pico, .file = "src/adc.zig" },
-    .{ .name = "pico_blinky", .target = rp2040.boards.raspberry_pi.pico, .file = "src/blinky.zig" },
-    // TODO: Fix multicore hal! .{ .name = "pico", .target = rp2040.boards.raspberry_pi.pico , .file = "src/blinky_core1.zig" },
-    .{ .name = "pico_flash-program", .target = rp2040.boards.raspberry_pi.pico, .file = "src/flash_program.zig" },
-    .{ .name = "pico_gpio-clk", .target = rp2040.boards.raspberry_pi.pico, .file = "src/gpio_clk.zig" },
-    .{ .name = "pico_i2c-bus-scan", .target = rp2040.boards.raspberry_pi.pico, .file = "src/i2c_bus_scan.zig" },
-    .{ .name = "pico_pwm", .target = rp2040.boards.raspberry_pi.pico, .file = "src/pwm.zig" },
-    .{ .name = "pico_random", .target = rp2040.boards.raspberry_pi.pico, .file = "src/random.zig" },
-    .{ .name = "pico_spi-master", .target = rp2040.boards.raspberry_pi.pico, .file = "src/spi_master.zig" },
-    .{ .name = "pico_squarewave", .target = rp2040.boards.raspberry_pi.pico, .file = "src/squarewave.zig" },
-    .{ .name = "pico_uart", .target = rp2040.boards.raspberry_pi.pico, .file = "src/uart.zig" },
-    .{ .name = "pico_usb-device", .target = rp2040.boards.raspberry_pi.pico, .file = "src/usb_device.zig" },
-    .{ .name = "pico_usb-hid", .target = rp2040.boards.raspberry_pi.pico, .file = "src/usb_hid.zig" },
-    .{ .name = "pico_ws2812", .target = rp2040.boards.raspberry_pi.pico, .file = "src/ws2812.zig" },
+    .{ .name = "pico_adc", .target = "board:raspberry_pi/pico", .file = "src/adc.zig" },
+    .{ .name = "pico_blinky", .target = "board:raspberry_pi/pico", .file = "src/blinky.zig" },
+    // TODO: Fix multicore hal! .{ .name = "pico", .target = "board:raspberry_pi/pico", .file = "src/blinky_core1.zig" },
+    .{ .name = "pico_flash-program", .target = "board:raspberry_pi/pico", .file = "src/flash_program.zig" },
+    .{ .name = "pico_gpio-clk", .target = "board:raspberry_pi/pico", .file = "src/gpio_clk.zig" },
+    .{ .name = "pico_i2c-bus-scan", .target = "board:raspberry_pi/pico", .file = "src/i2c_bus_scan.zig" },
+    .{ .name = "pico_pwm", .target = "board:raspberry_pi/pico", .file = "src/pwm.zig" },
+    .{ .name = "pico_random", .target = "board:raspberry_pi/pico", .file = "src/random.zig" },
+    .{ .name = "pico_spi-master", .target = "board:raspberry_pi/pico", .file = "src/spi_master.zig" },
+    .{ .name = "pico_squarewave", .target = "board:raspberry_pi/pico", .file = "src/squarewave.zig" },
+    .{ .name = "pico_uart", .target = "board:raspberry_pi/pico", .file = "src/uart.zig" },
+    .{ .name = "pico_usb-device", .target = "board:raspberry_pi/pico", .file = "src/usb_device.zig" },
+    .{ .name = "pico_usb-hid", .target = "board:raspberry_pi/pico", .file = "src/usb_hid.zig" },
+    .{ .name = "pico_ws2812", .target = "board:raspberry_pi/pico", .file = "src/ws2812.zig" },
 
-    .{ .name = "rp2040-matrix_tiles", .target = rp2040.boards.waveshare.rp2040_matrix, .file = "src/tiles.zig" },
-
-    //     .{ .name = "rp2040-eth", .target = rp2040.boards.waveshare.rp2040_eth },
-    //     .{ .name = "rp2040-plus-4m", .target = rp2040.boards.waveshare.rp2040_plus_4m },
-    //     .{ .name = "rp2040-plus-16m", .target = rp2040.boards.waveshare.rp2040_plus_16m },
+    .{ .name = "rp2040-matrix_tiles", .target = "board:waveshare/rp2040_matrix", .file = "src/tiles.zig" },
 };
 
 pub fn build(b: *std.Build) void {
-    const microzig = @import("microzig").init(b, "microzig");
+    const microzig = MicroZig.createBuildEnvironment(b, .{});
+
     const optimize = b.standardOptimizeOption(.{});
 
     for (available_examples) |example| {
+        const target = microzig.findTarget(example.target).?;
+
         // `addFirmware` basically works like addExecutable, but takes a
         // `microzig.Target` for target instead of a `std.zig.CrossTarget`.
         //
@@ -36,7 +36,7 @@ pub fn build(b: *std.Build) void {
         // cpu and potentially the board as well.
         const firmware = microzig.addFirmware(b, .{
             .name = example.name,
-            .target = example.target,
+            .target = target,
             .optimize = optimize,
             .source_file = .{ .path = example.file },
         });
@@ -53,7 +53,7 @@ pub fn build(b: *std.Build) void {
 }
 
 const Example = struct {
-    target: @import("microzig").Target,
+    target: []const u8,
     name: []const u8,
     file: []const u8,
 };

--- a/examples/raspberrypi-rp2040/build.zig.zon
+++ b/examples/raspberrypi-rp2040/build.zig.zon
@@ -3,12 +3,16 @@
     .version = "0.1.0",
     .dependencies = .{
         .microzig = .{
-            .url = "https://github.com/ZigEmbeddedGroup/microzig/archive/c6c9ec4516f57638e751141085c9d76120990312.tar.gz",
-            .hash = "1220af58bdaa721b8189f3a7adfda660517dd354463463388e96d69fe4ceccf80b92",
+            .url = "http://localhost:8080/microzig-build.tar.gz",
+            .hash = "1220db1de385b765aa45a04719c199d7ab8306fcca6ac1a12b487ed589a69d05a665",
         },
-        .rp2040 = .{
-            .url = "https://github.com/ZigEmbeddedGroup/raspberrypi-rp2040/archive/67d36eebb0fbd89633db1a51d6d2bcb049f2066a.tar.gz",
-            .hash = "122094bf268f45b188f3916f9e5964f4257414afaafba98a455ac47d25389a456832",
+        .@"microzig-core" = .{
+            .url = "http://localhost:8080/microzig-core.tar.gz",
+            .hash = "122006d6343021c1502ceba7948fd61ac813f2bb498a74df27a50e34398ccdfb92e3",
+        },
+        .@"microzig-bsp-rp2040" = .{
+            .url = "http://localhost:8080/board-support/raspberrypi/rp2040.tar.gz",
+            .hash = "12200319b02d9d0237984fd7acb15a4945e5547b750e0a3309d13d62440983b5b67f",
         },
     },
 }


### PR DESCRIPTION
Rework raspberry pico examples to support new
microzig architecture. This involves using newly
added target selection by bsp projects.